### PR TITLE
Fix error loading missing secondary model

### DIFF
--- a/prd.py
+++ b/prd.py
@@ -1768,15 +1768,14 @@ elif diffusion_model == '256x256_diffusion_uncond':
         'use_scale_shift_norm': True,
     })
 
-secondary_model_ver = 2
 model_default = model_config['image_size']
 
 
 
-if secondary_model_ver == 2:
+if use_secondary_model:
     secondary_model = SecondaryDiffusionImageNet2()
     secondary_model.load_state_dict(torch.load(f'{model_path}/secondary_model_imagenet_2.pth', map_location='cpu'))
-secondary_model.eval().requires_grad_(False).to(device)
+    secondary_model.eval().requires_grad_(False).to(device)
 
 clip_models = []
 if ViTB32 is True: clip_models.append(clip.load('ViT-B/32', jit=False)[0].eval().requires_grad_(False).to(device))


### PR DESCRIPTION
I found an error which occurs when `use_secondary_model` is false and the secondary model has not yet been downloaded. The script should be checking that the secondary model is enabled before attempting to use it.