### PR TITLE
Use Pillow>=9.1.0 to fix Resampling AttributeError

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ pip install grpcio
 ```
 pip install ipywidgets omegaconf pytorch_lightning einops
 pip install matplotlib pandas
+pip install 'Pillow>=9.1.0'
 conda install opencv
 ```
 **[Linux]** Depending on your Linux platform, you may get an error about libGL.so.1


### PR DESCRIPTION
Passing `--useinit` to `prd.py` raises `AttributeError`:

> AttributeError: module 'PIL.Image' has no attribute 'Resampling'

This is because the version of the Pillow package installed as a dependency by other packages has a bug that was fixed in `9.1.0` (see [release note](https://github.com/python-pillow/Pillow/releases/tag/9.1.0) and [relevant PR](https://github.com/python-pillow/Pillow/pull/5954)).

Pinning the version to `9.1.0` or higher fixes the issue.
