### PR TITLE
Pass in device to be used for CLIP models as they're loaded

### DIFF
--- a/prd.py
+++ b/prd.py
@@ -2505,47 +2505,56 @@ if ViTB32 is True:
     clip_modelname.append('ViTB32')
     clip_models.append(
         clip.load('ViT-B/32',
-                  jit=False)[0].eval().requires_grad_(False).to(device))
+                  jit=False,
+                  device=device)[0].eval().requires_grad_(False))
 if ViTB16 is True:
     clip_modelname.append('ViTB16')
     clip_models.append(
         clip.load('ViT-B/16',
-                  jit=False)[0].eval().requires_grad_(False).to(device))
+                  jit=False,
+                  device=device)[0].eval().requires_grad_(False))
 if ViTL14 is True:
     clip_modelname.append('ViTL14')
     clip_models.append(
         clip.load('ViT-L/14',
-                  jit=False)[0].eval().requires_grad_(False).to(device))
+                  jit=False,
+                  device=device)[0].eval().requires_grad_(False))
 if ViTL14_336 is True:
     clip_modelname.append('ViTL14_336')
     clip_models.append(
         clip.load('ViT-L/14@336px',
-                  jit=False)[0].eval().requires_grad_(False).to(device))
+                  jit=False,
+                  device=device)[0].eval().requires_grad_(False))
 if RN50 is True:
     clip_modelname.append('RN50')
     clip_models.append(
         clip.load('RN50',
-                  jit=False)[0].eval().requires_grad_(False).to(device))
+                  jit=False,
+                  device=device)[0].eval().requires_grad_(False))
 if RN50x4 is True:
     clip_modelname.append('RN50x4')
     clip_models.append(
         clip.load('RN50x4',
-                  jit=False)[0].eval().requires_grad_(False).to(device))
+                  jit=False,
+                  device=device)[0].eval().requires_grad_(False))
 if RN50x16 is True:
     clip_modelname.append('RN50x16')
     clip_models.append(
         clip.load('RN50x16',
-                  jit=False)[0].eval().requires_grad_(False).to(device))
+                  jit=False,
+                  device=device)[0].eval().requires_grad_(False))
 if RN50x64 is True:
     clip_modelname.append('RN50x64')
     clip_models.append(
         clip.load('RN50x64',
-                  jit=False)[0].eval().requires_grad_(False).to(device))
+                  jit=False,
+                  device=device)[0].eval().requires_grad_(False))
 if RN101 is True:
     clip_modelname.append('RN101')
     clip_models.append(
         clip.load('RN101',
-                  jit=False)[0].eval().requires_grad_(False).to(device))
+                  jit=False,
+                  device=device)[0].eval().requires_grad_(False))
 
 """
 if SLIPB16:


### PR DESCRIPTION
Per #49, when loading CLIP models, we were loading the model without specifying a device, then moving the model to the device specified by the CLI argument. This causes problems if the default device is already in use, as it may not have enough memory to load the model there before moving it to the desired device. By passing the desired device in to the CLIP load argument we avoid this.

Also when testing this, I ran into another issue with the with `torch.cuda.empty_cache()` causing CUDA OOM. Addressed this by wrapping all instances with context manager:
```
with torch.cuda.device(device):
    torch.cuda.empty_cache()
```