### PR TITLE
Add PIL safety mechanism for init_image and image resizing.

### DIFF
--- a/prd.py
+++ b/prd.py
@@ -936,6 +936,17 @@ def random_file(directory):
     file = random.choice(files)
     return(file)
 
+def get_resampling_mode():
+    try:
+        from PIL import __version__, Image
+        major_ver = int(__version__.split('.')[0])
+        if major_ver >= 9:
+            return Image.Resampling.LANCZOS
+        else:
+            return Image.LANCZOS
+    except Exception as ex:
+        return 1  # 'Lanczos' irrespective of version.
+
 # Check for init randomizer in settings, and configure a random init if found
 init_image_OriginalPath  = init_image
 if init_image != None:
@@ -951,7 +962,7 @@ if init_image != None:
         if (temp_width != width_height[0]) or (temp_height != width_height[1]):
             print('Randomly chosen init image does not match width and height from settings.')
             print('It will be resized as temp_init.png and used as your init.')
-            temp = temp.resize(width_height, Image.Resampling.LANCZOS)
+            temp = temp.resize(width_height, get_resampling_mode())
             temp.save('temp_init.png')
             init_image = 'temp_init.png'
 
@@ -1591,7 +1602,7 @@ def do_run():
         init = None
         if init_image is not None:
             init = Image.open(fetch(init_image)).convert('RGB')
-            init = init.resize((args.side_x, args.side_y), Image.Resampling.LANCZOS)
+            init = init.resize((args.side_x, args.side_y), get_resampling_mode())
             init = TF.to_tensor(init).to(device).unsqueeze(0).mul(2).sub(1)
 
         if args.perlin_init:
@@ -3221,7 +3232,7 @@ try:
             if cl_args.gobiginit_scaled == False:
                 reside_x = side_x * gobig_scale
                 reside_y = side_y * gobig_scale
-                source_image = input_image.resize((reside_x, reside_y), Image.Resampling.LANCZOS)
+                source_image = input_image.resize((reside_x, reside_y), get_resampling_mode())
             else:
                 source_image = Image.open(progress_image).convert('RGBA')
 


### PR DESCRIPTION
Hey there, encountered an issue with PIL barfing when trying to import `Image.Resampling.LANCZOS` since this is a newer (>9.0) flag, it was previously located at `Image.LANCZOS`. Using an init_image you can hit this early on in a run.

**tl;dr**: Added a safety mechanism to retrieve either `Image.Resampling.LANCZOS` or `Image.LANCZOS` depending on the version (<9.0 or >9.0) and fall back to '1' which is the numerical constant cross-version in any other case. Friendlier for more environments.

Since this is an extremely common library, most python environments are going to have some version installed already, and installing some random library might move your version around as well because the dependency is so common, so I added a safety mechanism for this that checks your PIL version and falls back to the numerical constant to make sure this always works.

#### PIL Reference:
https://pillow.readthedocs.io/en/stable/deprecations.html#constants

#### Tested with:
- Pillow 8.0.0
- Pillow 9.1.1

Exception:
```python
All image(s) finished.
Traceback (most recent call last):
  File "C:/.../progrockdiffusion/prd.py", line 3205, in <module>
    do_run()
  File "C:/.../progrockdiffusion/prd.py", line 1594, in do_run
    init = init.resize((args.side_x, args.side_y), Image.Resampling.LANCZOS)
  File "C:\python-3.9.2\lib\site-packages\PIL\Image.py", line 62, in __getattr__
    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
python-BaseExceptionle 'PIL.Image' has no attribute 'Resampling'
```