### PR TITLE
padding and 'heatmap' probability sampling for cuts

### DIFF
--- a/cut_modules/make_cutouts.py
+++ b/cut_modules/make_cutouts.py
@@ -2,6 +2,8 @@ import math
 import random
 import logging
 
+import numpy as np
+from scipy.ndimage.filters import gaussian_filter
 import torch
 from resize_right import resize
 from torch import nn
@@ -12,6 +14,27 @@ from PIL import ImageDraw
 
 
 logger = logging.getLogger(__name__)
+
+
+def save_inner_cut_bounds_image(input, bounds_list, f_name):
+    image = TF.to_pil_image(input.clamp(0, 1).squeeze(0))
+    draw = ImageDraw.Draw(image)
+    for points in bounds_list:
+        # Bounds are in form left, right, top, bottom.
+        # Convert that here to top left x and y, bottom right x and y.
+        draw.rectangle(
+            (points[0], points[2], points[1], points[3]),
+            outline=(255, 0, 0)
+        )
+    image.save(
+        f_name, quality=99
+    )
+
+
+def save_cut_image(cutout, f_name: str):
+    TF.to_pil_image(cutout.clamp(0, 1).squeeze(0)).save(
+        f_name, quality=99
+    )
 
 
 def sinc(x):
@@ -58,6 +81,78 @@ def resample(input, size, align_corners=True):
                          size,
                          mode='bicubic',
                          align_corners=align_corners)
+
+
+def center_to_bounds(center_x, center_y, cut_size, image_x, image_y):
+    pad_size = int(cut_size / 2)
+    left_bound = max((center_x - pad_size), 0)
+    right_bound = min((center_x + pad_size), image_x)
+    top_bound = max((center_y - pad_size), 0)
+    bottom_bound = min((center_y + pad_size), image_y)
+    return left_bound, right_bound, top_bound, bottom_bound
+
+
+def random_sample(side_x, side_y, inner_mask_size=0):
+    return (
+        torch.randint(inner_mask_size, side_x - inner_mask_size, ()),
+        torch.randint(inner_mask_size, side_y - inner_mask_size, ())
+    )
+
+
+class CutHeatmap(object):
+
+    def __init__(
+            self,
+            side_x,
+            side_y,
+            decay_scale=0.3,
+            decay_gaussian_sigma=7,
+            overlap_penalty_coef=0.3
+    ):
+        self.heatmap = np.ones((side_y, side_x), dtype=np.float32)
+        self.decay_scale = decay_scale
+        self.decay_gaussian_sigma = decay_gaussian_sigma
+        self.overlap_penalty_coef = overlap_penalty_coef
+
+    def add_cut(self, center_x, center_y, cut_size):
+        left, right, top, bottom = center_to_bounds(
+            center_x,
+            center_y,
+            cut_size,
+            image_x=self.heatmap.shape[-1],
+            image_y=self.heatmap.shape[-2]
+        )
+        self.heatmap[
+            top:bottom,
+            left:right
+        ] *= self.overlap_penalty_coef
+
+    def decay(self):
+        self.heatmap = gaussian_filter(self.heatmap, sigma=self.decay_gaussian_sigma)
+        self.heatmap = (
+            np.ones(self.heatmap.shape, dtype=np.float32) * self.decay_scale + self.heatmap
+        ) / (1 + self.decay_scale)
+
+    def sample_centerpoint(self, cut_size, padded=False):
+        cut_offset = int(cut_size / 2)
+        if padded:
+            # If we will pad the image, any centerpoint is valid
+            centerpoints = self.heatmap
+        else:
+            # Otherwise, only select points half a cut size away from the edge
+            centerpoints = self.heatmap[cut_offset:-cut_offset, cut_offset:-cut_offset]
+        linear_idx = np.random.choice(centerpoints.size, p=centerpoints.ravel() / float(centerpoints.sum()))
+        y, x = np.unravel_index(linear_idx, centerpoints.shape)
+        if not padded:
+            x += cut_offset
+            y += cut_offset
+        return x, y
+
+    def to_image(self):
+        return TF.to_pil_image(self.heatmap * 255).convert("RGB")
+
+    def save_image(self, name="cut_heatmap.jpg"):
+        self.to_image().save(name, quality=99)
 
 
 class MakeCutouts(nn.Module):
@@ -116,10 +211,10 @@ class MakeCutoutsDango(nn.Module):
     ):
         super().__init__()
         self.cut_size = cut_size
-        self.Overview = Overview
-        self.InnerCrop = InnerCrop
-        self.IC_Size_Pow = IC_Size_Pow
-        self.IC_Grey_P = IC_Grey_P
+        self.overview_cut_count = Overview
+        self.inner_cut_count = InnerCrop
+        self.inner_cut_size_exponent = IC_Size_Pow
+        self.inner_cut_grey_exponent = IC_Grey_P
         if animation_mode == 'None':
             self.augs = T.Compose([
                 T.RandomHorizontalFlip(p=0.5),
@@ -163,62 +258,91 @@ class MakeCutoutsDango(nn.Module):
                               hue=0.3),
             ])
 
-    def forward(self, input, skip_augs=False, padargs={}):
+    def forward(
+            self,
+            input,
+            skip_augs=False,
+            heatmap=None,
+            padargs={},
+            pad_inner=False,
+            fix_size=False
+    ):
         cutouts = []
         gray = T.Grayscale(3)
-        sideY, sideX = input.shape[2:4]
-        max_size = min(sideX, sideY)
-        min_size = min(sideX, sideY, self.cut_size)
-        l_size = max(sideX, sideY)
+        side_y, side_x = input.shape[2:4]
+
+        max_size = min(side_x, side_y)
+        min_size = min(side_x, side_y, self.cut_size)
         output_shape = [1, 3, self.cut_size, self.cut_size]
-        output_shape_2 = [1, 3, self.cut_size + 2, self.cut_size + 2]
-        pad_input = F.pad(input,
-                          ((sideY - max_size) // 2, (sideY - max_size) // 2,
-                           (sideX - max_size) // 2, (sideX - max_size) // 2),
-                          **padargs)
+
+        pad_input = F.pad(
+            input,
+            ((side_y - max_size) // 2, (side_y - max_size) // 2,
+            (side_x - max_size) // 2, (side_x - max_size) // 2),
+            **padargs
+        )
         cutout = resize(pad_input, out_shape=output_shape)
 
         # create a list of 1 to 4 in random order, then do the matching overview cut
         # This way even with less than 4 overview cuts, you still get a mix of all of them
-        if self.Overview > 0:
-            if self.Overview <= 4:
-                li = [1, 1, 2, 3, 4] # give a slight edge to the normal, full color cut
-                ri = random.sample(li, self.Overview)
-                ri.sort()
-                for i in range(self.Overview):
-                    if ri[i] == 1:
-                        cutouts.append(cutout)
-                    if ri[i] == 2:
-                        cutouts.append(gray(cutout))
-                    if ri[i] == 3:
-                        cutouts.append(TF.hflip(cutout))
-                    if ri[i] == 4:
-                        cutouts.append(gray(TF.hflip(cutout)))
-            else:
-                cutout = resize(pad_input, out_shape=output_shape)
-                for _ in range(self.Overview):
-                    if not skip_augs:
-                        cutouts.append(self.augs(cutout))
-                    else:
-                        cutouts.append(cutout)
-
-        innercut_bound_list = []
-        if self.InnerCrop > 0:
-            for i in range(self.InnerCrop):
-                size = int(
-                    torch.rand([]) ** self.IC_Size_Pow * (max_size - min_size) + min_size
-                )
-                offsetx = torch.randint(0, sideX - size + 1, ())
-                offsety = torch.randint(0, sideY - size + 1, ())
-                innercut_bound_list.append((offsetx, offsety, offsetx + size, offsety + size))
-                cutout = input[:, :, offsety:offsety + size,
-                         offsetx:offsetx + size]
-                if i <= int(self.IC_Grey_P * self.InnerCrop):
-                    cutout = gray(cutout)
-                cutout = resize(cutout, out_shape=output_shape)
+        if 0 < self.overview_cut_count <= 4:
+            li = [1, 1, 2, 3, 4] # give a slight edge to the normal, full color cut
+            ri = random.sample(li, self.overview_cut_count)
+            ri.sort()
+            for i in range(self.overview_cut_count):
+                if ri[i] == 1:
+                    cutouts.append(cutout)
+                if ri[i] == 2:
+                    cutouts.append(gray(cutout))
+                if ri[i] == 3:
+                    cutouts.append(TF.hflip(cutout))
+                if ri[i] == 4:
+                    cutouts.append(gray(TF.hflip(cutout)))
+        elif self.overview_cut_count > 4:
+            cutout = resize(pad_input, out_shape=output_shape)
+            for _ in range(self.overview_cut_count):
                 if not skip_augs:
                     cutouts.append(self.augs(cutout))
                 else:
                     cutouts.append(cutout)
+
+        innercut_bound_list = []
+        for i in range(self.inner_cut_count):
+            if fix_size:
+                size = min_size
+            else:
+                size = int(
+                    torch.rand([]) ** self.inner_cut_size_exponent * (max_size - min_size) + min_size
+                )
+            pad_size = int(size / 2) if pad_inner else 0
+            if heatmap:
+                center_x, center_y = heatmap.sample_centerpoint(size, padded=pad_inner)
+                heatmap.add_cut(center_x, center_y, size)
+            else:
+                inner_mask_size = 0 if pad_inner else int(size / 2)
+                center_x, center_y = random_sample(side_x, side_y, inner_mask_size=inner_mask_size)
+            if pad_inner:
+                pad = T.Pad(pad_size)
+                padded = pad(input)
+                left, right, top, bottom = center_to_bounds(
+                    center_x + pad_size,
+                    center_y + pad_size,
+                    size,
+                    side_x + size,
+                    side_y + size
+                )
+                innercut_bound_list.append((left - pad_size, right - pad_size, top - pad_size, bottom - pad_size))
+                cutout = padded[:, :, top:bottom, left:right]
+            else:
+                left, right, top, bottom = center_to_bounds(center_x, center_y, size, side_x, side_y)
+                innercut_bound_list.append((left, right, top, bottom))
+                cutout = input[:, :, top:bottom, left:right]
+            if i <= int(self.inner_cut_grey_exponent * self.inner_cut_count):
+                cutout = gray(cutout)
+            cutout = resize(cutout, out_shape=output_shape)
+            if not skip_augs:
+                cutouts.append(self.augs(cutout))
+            else:
+                cutouts.append(cutout)
         cutouts = torch.cat(cutouts)
         return cutouts, innercut_bound_list

--- a/model_managers/clip_manager.py
+++ b/model_managers/clip_manager.py
@@ -170,7 +170,7 @@ class ClipManager:
             save_cut_image(cutout, os.path.join(self.cutout_debug_image_dir, f"cutout_{self.name}_{i}.jpg"))
 
     def get_cut_batch_losses(
-            self,
+        self,
         x_in,
         n,
         cut_overview,

--- a/prd.py
+++ b/prd.py
@@ -2212,8 +2212,8 @@ clip_managers = [
         name=model_name,
         cut_count_multiplier=eval(model_name),
         device=device,
-        use_cut_heatmap=False,
-        pad_inner_cuts=False
+        use_cut_heatmap=True,
+        pad_inner_cuts=True
     )
     for model_name in CLIP_NAME_MAP.keys() if eval(model_name)
 ]

--- a/prd.py
+++ b/prd.py
@@ -2208,7 +2208,13 @@ model_load_name_map = {
 
 
 clip_managers = [
-    ClipManager(name=model_name, cut_count_multiplier=eval(model_name), device=device)
+    ClipManager(
+        name=model_name,
+        cut_count_multiplier=eval(model_name),
+        device=device,
+        use_cut_heatmap=True,
+        pad_inner_cuts=True
+    )
     for model_name in CLIP_NAME_MAP.keys() if eval(model_name)
 ]
 

--- a/prd.py
+++ b/prd.py
@@ -2212,8 +2212,8 @@ clip_managers = [
         name=model_name,
         cut_count_multiplier=eval(model_name),
         device=device,
-        use_cut_heatmap=True,
-        pad_inner_cuts=True
+        use_cut_heatmap=False,
+        pad_inner_cuts=False
     )
     for model_name in CLIP_NAME_MAP.keys() if eval(model_name)
 ]

--- a/tests/test_cuts.py
+++ b/tests/test_cuts.py
@@ -1,0 +1,202 @@
+import logging
+import os
+
+import torch
+import pytest
+
+import numpy as np
+from cut_modules import make_cutouts
+from cut_modules.make_cutouts import (
+    MakeCutoutsDango,
+    CutHeatmap,
+    save_inner_cut_bounds_image,
+    save_cut_image,
+    random_sample,
+    center_to_bounds
+)
+
+numeric_log_level = numeric_level = getattr(logging, 'DEBUG', None)
+logging.basicConfig(level=numeric_level)
+logger = logging.getLogger(__name__)
+
+
+class TestHeatmapSampling:
+
+    def test_heatmap_sample_padded(self):
+        image_x, image_y = 125, 100
+        # This test is probabilistic, which isn't ideal, but should be adequate here.
+        # There's a very small chance of a false positive, but no chance of false negative.
+        heatmap = CutHeatmap(side_x=image_x, side_y=image_y)
+        cut_size = 50
+
+        y_list = []
+        x_list = []
+
+        for _ in range(1000):
+            x, y = heatmap.sample_centerpoint(cut_size, padded=True)
+            y_list.append(y)
+            x_list.append(x)
+
+        assert max(x_list) < image_x
+        assert max(y_list) < image_y
+
+    def test_heatmap_sample_unpadded(self):
+        image_x, image_y = 125, 100
+        # This test is probabilistic, which isn't ideal, but should be adequate here.
+        # There's a very small chance of a false positive, but no chance of false negative.
+        heatmap = CutHeatmap(side_x=image_x, side_y=image_y)
+        cut_size = 50
+        pad_size = int(50 / 2) - 1
+
+        y_list = []
+        x_list = []
+
+        for _ in range(1000):
+            x, y = heatmap.sample_centerpoint(cut_size, padded=False)
+            y_list.append(y)
+            x_list.append(x)
+
+        assert max(x_list) < image_x - pad_size
+        assert max(y_list) < image_y - pad_size
+        assert min(x_list) >= pad_size
+        assert min(y_list) >= pad_size
+
+
+class TestRandomSampling:
+    def test_random_sample_padded(self):
+        """
+        If we're adding padding to the outside of the image to allow cuts to extend
+        over the edge of the image, we want our center point samples to range all the
+        way to the edge of the image.
+        """
+        image_x, image_y = 125, 100
+        cut_size = 50
+        pad_size = int(cut_size / 2)
+
+        y_list = []
+        x_list = []
+
+        for _ in range(1000):
+            x, y = random_sample(side_x=image_x, side_y=image_y)
+            y_list.append(y)
+            x_list.append(x)
+
+        # Check that our sampled x and y values are all within the image, but can extend up to the edges
+        assert image_x - pad_size < max(x_list) < image_x
+        assert image_y - pad_size < max(y_list) < image_y
+
+    def test_random_sample_unpadded(self):
+        image_x, image_y = 125, 100
+        cut_size = 50
+        pad_size = int(cut_size / 2)
+
+        y_list = []
+        x_list = []
+
+        for _ in range(1000):
+            x, y = random_sample(side_x=image_x, side_y=image_y, inner_mask_size=pad_size)
+            y_list.append(y)
+            x_list.append(x)
+
+        # Check that our sampled x and y values are all far enough from the edge that the cut won't
+        # extend beyond the edge
+        assert max(x_list) < image_x - pad_size
+        assert max(y_list) < image_y - pad_size
+
+
+class TestCutouts:
+
+    @staticmethod
+    def save_test_images(name_prefix, image, bounds_list, cuts, heatmap):
+        test_output_dir = 'test_output'
+        if not os.path.exists(test_output_dir):
+            os.makedirs(test_output_dir)
+        if heatmap:
+            heatmap.save_image(os.path.join(test_output_dir, f"{name_prefix}_heatmap.jpg"))
+        save_inner_cut_bounds_image(image, bounds_list, (os.path.join(test_output_dir, f"{name_prefix}_bounds.jpg")))
+        for i, cut in enumerate(cuts):
+            save_cut_image(cut, os.path.join(test_output_dir, f"{name_prefix}_cut_{i}.jpg"))
+
+    @pytest.fixture
+    def cutout_module(self):
+        return MakeCutoutsDango(
+            cut_size=20,
+            Overview=0,
+            InnerCrop=1,
+            IC_Size_Pow=100,
+        )
+
+    @pytest.fixture
+    def image_and_heatmap(self, request):
+        image_x, image_y = request.param
+        heatmap = CutHeatmap(side_x=image_x, side_y=image_y)
+        test_image = torch.ones((1, 3, image_y, image_x))
+        heatmap.heatmap = np.zeros(test_image.shape[-2:], dtype=np.float32)
+        for i in range(test_image.shape[-2]):
+            if i % 10 == 0:
+                test_image[:, :, i - 4:i, :] = 0.5
+        for j in range(test_image.shape[-1]):
+            if j % 10 == 0:
+                test_image[:, :, :, j - 4:j] = 0.5
+        return test_image, heatmap
+
+    @pytest.mark.parametrize('image_and_heatmap', [(125, 100)], indirect=True)
+    def test_centered_padded_heatmap_cutout(self, image_and_heatmap, cutout_module):
+        image, heatmap = image_and_heatmap
+        heatmap.heatmap[50, 50] = 1.0
+        cuts, bounds_list = cutout_module(
+            image,
+            pad_inner=True,
+            heatmap=heatmap,
+            fix_size=True,
+            skip_augs=True
+        )
+        self.save_test_images("test_centered_padded_heatmap_cutout", image, bounds_list, cuts, heatmap)
+        assert bounds_list[0] == (40, 60, 40, 60)
+        assert cuts[0].shape == (3, 20, 20)
+
+    @pytest.mark.parametrize('image_and_heatmap', [(125, 100)], indirect=True)
+    def test_corner_padded_heatmap_cutout(self, image_and_heatmap, cutout_module):
+        image, heatmap = image_and_heatmap
+        heatmap.heatmap[0, 0] = 1.0
+        cuts, bounds_list = cutout_module(
+            image,
+            pad_inner=True,
+            heatmap=heatmap,
+            fix_size=True,
+            skip_augs=True
+        )
+        self.save_test_images("test_corner_padded_heatmap_cutout", image, bounds_list, cuts, heatmap)
+        assert bounds_list[0] == (-10, 10, -10, 10)
+        assert cuts[0].shape == (3, 20, 20)
+
+    @pytest.mark.parametrize('image_and_heatmap', [(125, 100)], indirect=True)
+    def test_corner_unpadded_heatmap_cutout(self, image_and_heatmap, cutout_module):
+        image, heatmap = image_and_heatmap
+        heatmap.heatmap[10, 114] = 1.0
+        cuts, bounds_list = cutout_module(
+            image,
+            pad_inner=False,
+            heatmap=heatmap,
+            fix_size=True,
+            skip_augs=True
+        )
+        self.save_test_images("test_corner_unpadded_heatmap_cutout", image, bounds_list, cuts, heatmap)
+        assert bounds_list[0] == (104, 124, 0, 20)
+        assert cuts[0].shape == (3, 20, 20)
+
+    @pytest.mark.parametrize('image_and_heatmap', [(125, 100)], indirect=True)
+    def test_corner_unpadded_no_heatmap_cutout(self, image_and_heatmap, cutout_module, monkeypatch):
+        def mock_random_sample(*args, **kwargs):
+            return 114, 10  # center_x, center_y
+        monkeypatch.setattr(make_cutouts, "random_sample", mock_random_sample)
+        image, _ = image_and_heatmap
+        cuts, bounds_list = cutout_module(
+            image,
+            pad_inner=False,
+            fix_size=True,
+            skip_augs=True
+        )
+        self.save_test_images("test_corner_unpadded_no_heatmap_cutout", image, bounds_list, cuts, None)
+        assert bounds_list[0] == (104, 124, 0, 20)
+        assert cuts[0].shape == (3, 20, 20)


### PR DESCRIPTION
- Add 'heatmap' inner cut selection strategy. This initialized a uniform probability distribution over pixels in the image, then for each cut, selects a center point from this distribution. As each cut is selected, the probability distribution is updated to penalize the pixels covered by that cut. This probability map is persisted across cuts. After each step, it will decay by a set amount back towards the initial uniform distribution.
- Add cut padding option. This will allow inner cuts to extend over the edge of the image, using black pixels for these regions.
- Add some pytest tests around this cut-related functionality.
- Add/improve cut debug image outputs, including output for the cut heatmaps, and moving these images to their own subdirectory to avoid excessive clutter.
- A few minor clean-ups/name changes in the cutout module.