### PR TITLE
strip the input weight string

### DIFF
--- a/model_managers/clip_manager.py
+++ b/model_managers/clip_manager.py
@@ -69,7 +69,7 @@ class ClipManager:
         else:
             vals = prompt.rsplit(':', 1)
         vals = vals + ['', '1'][len(vals):]
-        return vals[0], float(numexpr.evaluate(vals[1], local_dict=vars))
+        return vals[0], float(numexpr.evaluate(vals[1].strip(), local_dict=vars))
 
     def load(self):
         with track_model_vram(self.device, f"Loading {self.name}"):


### PR DESCRIPTION
numexpr.evaluate doesn't strip the input string, but add a space before the weight is very common by users. So strip the users input string will be better.